### PR TITLE
Support symlinks for /etc/eselect/net/{devs,conf.d} and minor improvements

### DIFF
--- a/net.eselect
+++ b/net.eselect
@@ -27,7 +27,7 @@ file_ifacename() {
 }
 
 interface_config_file() {
-	[[ -z "$1" ]] && die "no interface provided"
+	[[ $# -lt 1 ]] && die "no interface provided"
 
 	local devname=${1#net\.}
 	local devrc="net.$devname"
@@ -52,9 +52,9 @@ interface_config_file() {
 }
 
 delete_config() {
-	[[ -z "$1" ]] && die "No DB file provided"
+	[[ $# -lt 1 ]] && die "No DB file provided"
 
-	[[ -z "$2" ]] && die "No key provided"
+	[[ $# -lt 2 ]] && die "No key provided"
 
 	sed -i -e "/^$2=/d" $1
 }
@@ -70,10 +70,10 @@ describe_show_parameters() {
 }
 
 do_show() {
-	if [[ -z "${@}" ]]; then
+	if [[ $# -eq 0 ]]; then
 		show_current_configs
 
-	elif [[ -z "$2" ]]; then
+	elif [[ $# -eq 1 ]]; then
 		show_interface_config "$1" --brief
 
 	else
@@ -232,9 +232,9 @@ describe_unset_parameters() {
 }
 
 do_unset() {
-	[[ -z "${1}" ]] && die -q "No interface provided"
+	[[ $# -lt 1 ]] && die -q "No interface provided"
 
-	[[ -n "${2}" ]] && die -q "Too many parameters"
+	[[ $# -gt 1 ]] && die -q "Too many parameters"
 
 	local devconf=${EROOT}/etc/conf.d/net.$1
 
@@ -299,7 +299,7 @@ describe_update_parameters() {
 do_update() {
 	local config
 
-	if [[ -z "$1" ]]; then
+	if [[ $# -lt 1 ]]; then
 		die -q "No interface provided"
 	fi
 


### PR DESCRIPTION
For keeping common configurations in a shared directory, a symlink for ${EROOT}/etc/eselect/net/conf.d is very convenient. Previously, if this was a symlink, eselect-net could not read its content ("find" does not resolve the link). Similarly, if .../devs was a symlink, eselect-net would fail to recognize that it generated the corresponding configuration ("canonicalise" is applied only on one side of the comparison).

There are some further minor improvements in the code like more careful quoting and dealing with empty arguments being passed.